### PR TITLE
Remove amp channel column

### DIFF
--- a/buzsaki_lab_to_nwb/new_code/yutanwbconverter.py
+++ b/buzsaki_lab_to_nwb/new_code/yutanwbconverter.py
@@ -277,13 +277,8 @@ class YutaNWBConverter(NWBConverter):
                         },
                         {
                             'name': 'shank_electrode_number',
-                            'description': '1-indexed channel within a shank',
+                            'description': '0-indexed channel within a shank',
                             'data': shank_electrode_number
-                        },
-                        {
-                            'name': 'amp_channel',
-                            'description': 'order in which the channels were plugged into amp',
-                            'data': [x for _, channels in enumerate(shank_channels) for _, x in enumerate(channels)]
                         }
                     ],
                     'ElectricalSeries': {


### PR DESCRIPTION
As per the previous discussion, electrodes are now inserted into the table in amp order rather than shank order; this removes the need for the amp_channel metadata column since the information is duplicated.