### PR TITLE
Comply with new nwb conversion schema

### DIFF
--- a/buzsaki_lab_to_nwb/__init__.py
+++ b/buzsaki_lab_to_nwb/__init__.py
@@ -1,1 +1,1 @@
-from .new_code.yutanwbconverter import YutaNWBConverter
+from .yuta_code.yutanwbconverter import YutaNWBConverter

--- a/buzsaki_lab_to_nwb/yuta_code/convert_yuta.py
+++ b/buzsaki_lab_to_nwb/yuta_code/convert_yuta.py
@@ -47,14 +47,14 @@ def run_yuta_conv(session, nwbfile_path):
 
             # construct input_args dict according to input schema
             input_args = dict(
-                source_data=dict(
-                    file_path=os.path.join(session, session_name) + ".dat",
+                NeuroscopeRecording=dict(file_path=os.path.join(session, session_name) + ".dat"),
+                NeuroscopeSorting=dict(
                     folder_path=session,
+                    keep_mua_units=False
                 ),
-                conversion_options=dict(
-                    keep_mua_units=False,
-                    exclude_shanks=None
-                )
+                YutaPosition=dict(folder_path=session),
+                YutaLFP=dict(folder_path=session),
+                YutaBehavior=dict(folder_path=session)
             )
 
             yuta_converter = YutaNWBConverter(**input_args)

--- a/buzsaki_lab_to_nwb/yuta_code/convert_yuta.py
+++ b/buzsaki_lab_to_nwb/yuta_code/convert_yuta.py
@@ -6,7 +6,7 @@ import os
 import pandas as pd
 from joblib import Parallel, delayed
 
-n_jobs = 1  # number of parallel streams to run
+n_jobs = 4  # number of parallel streams to run
 
 # List of folder paths to iterate over
 base_path = "D:/BuzsakiData/SenzaiY"

--- a/buzsaki_lab_to_nwb/yuta_code/convert_yuta.py
+++ b/buzsaki_lab_to_nwb/yuta_code/convert_yuta.py
@@ -6,7 +6,7 @@ import os
 import pandas as pd
 from joblib import Parallel, delayed
 
-n_jobs = 4  # number of parallel streams to run
+n_jobs = 1  # number of parallel streams to run
 
 # List of folder paths to iterate over
 base_path = "D:/BuzsakiData/SenzaiY"

--- a/buzsaki_lab_to_nwb/yuta_code/convert_yuta.py
+++ b/buzsaki_lab_to_nwb/yuta_code/convert_yuta.py
@@ -11,6 +11,10 @@ n_jobs = 1  # number of parallel streams to run
 # List of folder paths to iterate over
 base_path = "D:/BuzsakiData/SenzaiY"
 # base_path = "/mnt/scrap/cbaker239/SenzaiY"
+
+# Manual list of selected sessions that cause problems with the general functionality
+exlude_sessions = ["YutaMouse33-150218"]
+
 paper_sessions = pd.read_excel(os.path.join(base_path, "DGProject/DG_all_6_SessionShankList.xls"), header=None)[0]
 sessions = dict()
 for paper_session in paper_sessions:
@@ -82,4 +86,5 @@ def run_yuta_conv(session, nwbfile_path):
 
 
 Parallel(n_jobs=n_jobs)(delayed(run_yuta_conv)(session, nwbfile_path)
-                         for session, nwbfile_path in zip(session_strings, nwbfile_paths))
+                        for session, nwbfile_path in zip(session_strings, nwbfile_paths)
+                        if session not in exlude_sessions)

--- a/buzsaki_lab_to_nwb/yuta_code/convert_yuta.py
+++ b/buzsaki_lab_to_nwb/yuta_code/convert_yuta.py
@@ -87,4 +87,4 @@ def run_yuta_conv(session, nwbfile_path):
 
 Parallel(n_jobs=n_jobs)(delayed(run_yuta_conv)(session, nwbfile_path)
                         for session, nwbfile_path in zip(session_strings, nwbfile_paths)
-                        if session not in exlude_sessions)
+                        if os.path.split(session)[1] not in exlude_sessions)

--- a/buzsaki_lab_to_nwb/yuta_code/convert_yuta.py
+++ b/buzsaki_lab_to_nwb/yuta_code/convert_yuta.py
@@ -48,15 +48,12 @@ def run_yuta_conv(session, nwbfile_path):
             # construct input_args dict according to input schema
             input_args = dict(
                 source_data=dict(
-                    NeuroscopeRecording=dict(file_path=os.path.join(session, session_name) + ".dat"),
-                    NeuroscopeSorting=dict(
-                        folder_path=session,
-                        keep_mua_units=False,
-                        exclude_shanks=None
-                    ),
-                    YutaPosition=dict(folder_path=session),
-                    YutaLFP=dict(folder_path=session),
-                    YutaBehavior=dict(folder_path=session)
+                    file_path=os.path.join(session, session_name) + ".dat",
+                    folder_path=session,
+                ),
+                conversion_options=dict(
+                    keep_mua_units=False,
+                    exclude_shanks=None
                 )
             )
 

--- a/buzsaki_lab_to_nwb/yuta_code/convert_yuta.py
+++ b/buzsaki_lab_to_nwb/yuta_code/convert_yuta.py
@@ -6,7 +6,7 @@ import os
 import pandas as pd
 from joblib import Parallel, delayed
 
-n_cores = 1  # number of parallel streams to run
+n_jobs = 1  # number of parallel streams to run
 
 # List of folder paths to iterate over
 base_path = "D:/BuzsakiData/SenzaiY"
@@ -81,5 +81,5 @@ def run_yuta_conv(session, nwbfile_path):
         print(f"The folder ({session}) does not exist!")
 
 
-Parallel(n_jobs=n_cores)(delayed(run_yuta_conv)(session, nwbfile_path)
+Parallel(n_jobs=n_jobs)(delayed(run_yuta_conv)(session, nwbfile_path)
                          for session, nwbfile_path in zip(session_strings, nwbfile_paths))

--- a/buzsaki_lab_to_nwb/yuta_code/yutabehaviordatainterface.py
+++ b/buzsaki_lab_to_nwb/yuta_code/yutabehaviordatainterface.py
@@ -15,7 +15,14 @@ class YutaBehaviorInterface(BaseDataInterface):
 
     @classmethod
     def get_input_schema(cls):
-        return {}
+        return dict(
+            source_data=dict(
+                required=['folder_path'],
+                properties=dict(
+                    folder_path=dict(type='string')
+                )
+            )
+        )
 
     def __init__(self, **input_args):
         super().__init__(**input_args)
@@ -38,7 +45,6 @@ class YutaBehaviorInterface(BaseDataInterface):
         task_types = metadata_dict['task_types']
 
         subject_path, session_id = os.path.split(session_path)
-        fpath_base = os.path.split(subject_path)[0]
 
         [nwbfile.add_stimulus(x) for x in get_events(session_path)]
 
@@ -88,7 +94,7 @@ class YutaBehaviorInterface(BaseDataInterface):
         if os.path.isfile(trialdata_path):
             trials_data = loadmat(trialdata_path)['EightMazeRun']
 
-            trialdatainfo_path = os.path.join(fpath_base, 'EightMazeRunInfo.mat')
+            trialdatainfo_path = os.path.join(subject_path, 'EightMazeRunInfo.mat')
             trialdatainfo = [x[0] for x in loadmat(trialdatainfo_path)['EightMazeRunInfo'][0]]
 
             features = trialdatainfo[:7]

--- a/buzsaki_lab_to_nwb/yuta_code/yutabehaviordatainterface.py
+++ b/buzsaki_lab_to_nwb/yuta_code/yutabehaviordatainterface.py
@@ -16,11 +16,9 @@ class YutaBehaviorInterface(BaseDataInterface):
     @classmethod
     def get_input_schema(cls):
         return dict(
-            source_data=dict(
-                required=['folder_path'],
-                properties=dict(
-                    folder_path=dict(type='string')
-                )
+            required=['folder_path'],
+            properties=dict(
+                folder_path=dict(type='string')
             )
         )
 

--- a/buzsaki_lab_to_nwb/yuta_code/yutalfpdatainterface.py
+++ b/buzsaki_lab_to_nwb/yuta_code/yutalfpdatainterface.py
@@ -15,11 +15,9 @@ class YutaLFPInterface(BaseDataInterface):
     @classmethod
     def get_input_schema(cls):
         return dict(
-            source_data=dict(
-                required=['folder_path'],
-                properties=dict(
-                    folder_path=dict(type='string')
-                )
+            required=['folder_path'],
+            properties=dict(
+                folder_path=dict(type='string')
             )
         )
 

--- a/buzsaki_lab_to_nwb/yuta_code/yutalfpdatainterface.py
+++ b/buzsaki_lab_to_nwb/yuta_code/yutalfpdatainterface.py
@@ -14,8 +14,14 @@ class YutaLFPInterface(BaseDataInterface):
 
     @classmethod
     def get_input_schema(cls):
-        return {}
-
+        return dict(
+            source_data=dict(
+                required=['folder_path'],
+                properties=dict(
+                    folder_path=dict(type='string')
+                )
+            )
+        )
 
     def __init__(self, **input_args):
         super().__init__(**input_args)
@@ -44,7 +50,7 @@ class YutaLFPInterface(BaseDataInterface):
 
         subject_path, session_id = os.path.split(session_path)
 
-        _, all_channels_lfp_data = read_lfp(session_path, stub=stub_test)
+        _, all_channels_lfp_data = read_lfp(session_path, stub=stub_test, n_channels=80) # temporary hard-code
         lfp_data = all_channels_lfp_data[:, all_shank_channels]
         lfp_ts = write_lfp(nwbfile, lfp_data, lfp_sampling_rate,
                            name=metadata_dict['lfp']['name'],

--- a/buzsaki_lab_to_nwb/yuta_code/yutalfpdatainterface.py
+++ b/buzsaki_lab_to_nwb/yuta_code/yutalfpdatainterface.py
@@ -50,7 +50,7 @@ class YutaLFPInterface(BaseDataInterface):
 
         subject_path, session_id = os.path.split(session_path)
 
-        _, all_channels_lfp_data = read_lfp(session_path, stub=stub_test, n_channels=80) # temporary hard-code
+        _, all_channels_lfp_data = read_lfp(session_path, stub=stub_test)
         lfp_data = all_channels_lfp_data[:, all_shank_channels]
         lfp_ts = write_lfp(nwbfile, lfp_data, lfp_sampling_rate,
                            name=metadata_dict['lfp']['name'],

--- a/buzsaki_lab_to_nwb/yuta_code/yutanwbconverter.py
+++ b/buzsaki_lab_to_nwb/yuta_code/yutanwbconverter.py
@@ -98,26 +98,25 @@ class YutaNWBConverter(NWBConverter):
     )
 
     def __init__(self, **input_args):
-        dat_filepath = input_args['source_data'].get('NeuroscopeRecording', {}).get('file_path', None)
+        dat_filepath = input_args['source_data'].get('file_path', None)
         if not os.path.isfile(dat_filepath):
-            new_data_interface_classes = {}
+            new_data_interface_classes = dict()
 
             new_data_interface_classes.update({'YutaNoRecording': YutaNoRecording})
             for name, val in self.data_interface_classes.items():
                 new_data_interface_classes.update({name: val})
             new_data_interface_classes.pop('NeuroscopeRecording')
 
-            session_id = os.path.split(input_args['source_data']['NeuroscopeSorting']['folder_path'])[1]
-            xml_filepath = os.path.join(input_args['source_data']['NeuroscopeSorting']['folder_path'], session_id + '.xml')
+            session_id = os.path.split(input_args['source_data']['folder_path'])[1]
+            xml_filepath = os.path.join(input_args['source_data']['folder_path'], session_id + '.xml')
             root = et.parse(xml_filepath).getroot()
             n_channels = len([int(channel.text)
                               for group in root.find('spikeDetection').find('channelGroups').findall('group')
                               for channel in group.find('channels')])
             # The only information needed for this is .get_channel_ids() which is set by the shape of the input series
-            input_args['source_data'].update({'YutaNoRecording': {'timeseries': np.array(range(n_channels)),
-                                                                  'sampling_frequency': 1,
-                                                                  'geom': None}})
-            input_args['source_data'].pop('NeuroscopeRecording')
+            input_args['source_data'].update({'timeseries': np.array(range(n_channels)),
+                                              'sampling_frequency': 1,
+                                              'geom': None})
             self.data_interface_classes = new_data_interface_classes
             self._recording_type = 'YutaNoRecording'
         else:

--- a/buzsaki_lab_to_nwb/yuta_code/yutanwbconverter.py
+++ b/buzsaki_lab_to_nwb/yuta_code/yutanwbconverter.py
@@ -98,25 +98,25 @@ class YutaNWBConverter(NWBConverter):
     )
 
     def __init__(self, **input_args):
-        dat_filepath = input_args['source_data'].get('file_path', None)
+        dat_filepath = input_args.get('NeuroscopeRecording', {}).get('file_path', None)
         if not os.path.isfile(dat_filepath):
-            new_data_interface_classes = dict()
+            new_data_interface_classes = {}
 
             new_data_interface_classes.update({'YutaNoRecording': YutaNoRecording})
             for name, val in self.data_interface_classes.items():
                 new_data_interface_classes.update({name: val})
             new_data_interface_classes.pop('NeuroscopeRecording')
 
-            session_id = os.path.split(input_args['source_data']['folder_path'])[1]
-            xml_filepath = os.path.join(input_args['source_data']['folder_path'], session_id + '.xml')
+            session_id = os.path.split(input_args['NeuroscopeSorting']['folder_path'])[1]
+            xml_filepath = os.path.join(input_args['NeuroscopeSorting']['folder_path'], session_id + '.xml')
             root = et.parse(xml_filepath).getroot()
-            n_channels = len([int(channel.text)
-                              for group in root.find('spikeDetection').find('channelGroups').findall('group')
-                              for channel in group.find('channels')])
+            n_channels = len([[int(channel.text)
+                              for channel in group.find('channels')]
+                              for group in root.find('spikeDetection').find('channelGroups').findall('group')])
             # The only information needed for this is .get_channel_ids() which is set by the shape of the input series
-            input_args['source_data'].update({'timeseries': np.array(range(n_channels)),
-                                              'sampling_frequency': 1,
-                                              'geom': None})
+            input_args.update({'YutaNoRecording': {'timeseries': np.array(range(n_channels)),
+                                                   'sampling_frequency': 1}})
+            input_args.pop('NeuroscopeRecording')
             self.data_interface_classes = new_data_interface_classes
             self._recording_type = 'YutaNoRecording'
         else:
@@ -133,8 +133,8 @@ class YutaNWBConverter(NWBConverter):
         # TODO: improve mouse_number extraction
         mouse_number = session_id[9:11]
         # TODO: add error checking on file existence
-        subject_xls = os.path.join(subject_path, 'YM' + mouse_number + ' exp_sheet.xlsx')
-        hilus_csv_path = os.path.join(subject_path, 'early_session_hilus_chans.csv')
+        subject_xls = os.path.join(subject_path, 'DGProject/YM' + mouse_number + ' exp_sheet.xlsx')
+        hilus_csv_path = os.path.join(subject_path, 'DGProject/early_session_hilus_chans.csv')
         if '-' in session_id:
             subject_id, date_text = session_id.split('-')
             b = False

--- a/buzsaki_lab_to_nwb/yuta_code/yutanwbconverter.py
+++ b/buzsaki_lab_to_nwb/yuta_code/yutanwbconverter.py
@@ -65,7 +65,7 @@ def get_UnitFeatureCell_features(fpath_base, session_id, session_path, nshanks):
     """
     # TODO: add file existence checks
     cols_to_get = ('fineCellType', 'region', 'unitID', 'unitIDshank', 'shank')
-    matin = loadmat(os.path.join(fpath_base, '_extra/DG_all_6/DG_all_6__UnitFeatureSummary_add.mat'),
+    matin = loadmat(os.path.join(fpath_base, 'DGProject/DG_all_6__UnitFeatureSummary_add.mat'),
                     struct_as_record=False)['UnitFeatureCell'][0][0]
 
     all_ids = []
@@ -89,32 +89,35 @@ def get_UnitFeatureCell_features(fpath_base, session_id, session_path, nshanks):
 class YutaNWBConverter(NWBConverter):
     # The order of this dictionary matter significantly, but python dictionaries are supposed to be unordered
     # This is compensated for the time being, but should this conceptually be a list instead?
-    data_interface_classes = {'NeuroscopeRecording': neuroscopedatainterface.NeuroscopeRecordingInterface,
-                              'NeuroscopeSorting': neuroscopedatainterface.NeuroscopeSortingInterface,
-                              'YutaPosition': YutaPositionInterface,
-                              'YutaLFP': YutaLFPInterface,
-                              'YutaBehavior': YutaBehaviorInterface}
+    data_interface_classes = dict(
+            NeuroscopeRecording=neuroscopedatainterface.NeuroscopeRecordingInterface,
+            NeuroscopeSorting=neuroscopedatainterface.NeuroscopeSortingInterface,
+            YutaPosition=YutaPositionInterface,
+            YutaLFP=YutaLFPInterface,
+            YutaBehavior=YutaBehaviorInterface
+    )
 
     def __init__(self, **input_args):
-        dat_filepath = input_args.get('NeuroscopeRecording', {}).get('file_path', None)
+        dat_filepath = input_args['source_data'].get('NeuroscopeRecording', {}).get('file_path', None)
         if not os.path.isfile(dat_filepath):
             new_data_interface_classes = {}
-            
+
             new_data_interface_classes.update({'YutaNoRecording': YutaNoRecording})
             for name, val in self.data_interface_classes.items():
                 new_data_interface_classes.update({name: val})
             new_data_interface_classes.pop('NeuroscopeRecording')
 
-            session_id = os.path.split(input_args['NeuroscopeSorting']['folder_path'])[1]
-            xml_filepath = os.path.join(input_args['NeuroscopeSorting']['folder_path'], session_id + '.xml')
+            session_id = os.path.split(input_args['source_data']['NeuroscopeSorting']['folder_path'])[1]
+            xml_filepath = os.path.join(input_args['source_data']['NeuroscopeSorting']['folder_path'], session_id + '.xml')
             root = et.parse(xml_filepath).getroot()
-            n_channels = len([[int(channel.text)
-                              for channel in group.find('channels')]
-                              for group in root.find('spikeDetection').find('channelGroups').findall('group')])
+            n_channels = len([int(channel.text)
+                              for group in root.find('spikeDetection').find('channelGroups').findall('group')
+                              for channel in group.find('channels')])
             # The only information needed for this is .get_channel_ids() which is set by the shape of the input series
-            input_args.update({'YutaNoRecording': {'timeseries': np.array(range(n_channels)),
-                                                   'sampling_frequency': 1}})
-            input_args.pop('NeuroscopeRecording')
+            input_args['source_data'].update({'YutaNoRecording': {'timeseries': np.array(range(n_channels)),
+                                                                  'sampling_frequency': 1,
+                                                                  'geom': None}})
+            input_args['source_data'].pop('NeuroscopeRecording')
             self.data_interface_classes = new_data_interface_classes
             self._recording_type = 'YutaNoRecording'
         else:
@@ -128,12 +131,11 @@ class YutaNWBConverter(NWBConverter):
         # TODO: could be vastly improved with pathlib
         session_path = self.data_interface_objects['NeuroscopeSorting'].input_args['folder_path']
         subject_path, session_id = os.path.split(session_path)
-        fpath_base = os.path.split(subject_path)[0]
         # TODO: improve mouse_number extraction
         mouse_number = session_id[9:11]
         # TODO: add error checking on file existence
         subject_xls = os.path.join(subject_path, 'YM' + mouse_number + ' exp_sheet.xlsx')
-        hilus_csv_path = os.path.join(fpath_base, 'early_session_hilus_chans.csv')
+        hilus_csv_path = os.path.join(subject_path, 'early_session_hilus_chans.csv')
         if '-' in session_id:
             subject_id, date_text = session_id.split('-')
             b = False
@@ -159,7 +161,7 @@ class YutaNWBConverter(NWBConverter):
             age = 'unknown'
             subject_data = {}
             subject_data.update({'genotype': 'unknown'})
-            print("Warning: no subject file detected!")
+            print(f"Warning: no subject file detected for session {session_path}!")
 
         # TODO: add error checking on file existence
         xml_filepath = os.path.join(session_path, session_id + '.xml')
@@ -169,6 +171,7 @@ class YutaNWBConverter(NWBConverter):
         shank_channels = [[int(channel.text)
                           for channel in group.find('channels')]
                           for group in root.find('spikeDetection').find('channelGroups').findall('group')]
+
         all_shank_channels = np.concatenate(shank_channels)
         all_shank_channels.sort()
         nshanks = len(shank_channels)
@@ -218,7 +221,7 @@ class YutaNWBConverter(NWBConverter):
                                            'channel': channel,
                                            'description': 'environmental electrode recorded inline with neural data'})
 
-        df_unit_features = get_UnitFeatureCell_features(fpath_base, session_id, session_path, nshanks)
+        df_unit_features = get_UnitFeatureCell_features(subject_path, session_id, session_path, nshanks)
 
         # there are occasional mismatches between the matlab struct
         # and the neuroscope files regions: 3: 'CA3', 4: 'DG'

--- a/buzsaki_lab_to_nwb/yuta_code/yutapositiondatainterface.py
+++ b/buzsaki_lab_to_nwb/yuta_code/yutapositiondatainterface.py
@@ -12,11 +12,9 @@ class YutaPositionInterface(BaseDataInterface):
     @classmethod
     def get_input_schema(cls):
         return dict(
-            source_data=dict(
-                required=['folder_path'],
-                properties=dict(
-                    folder_path=dict(type='string')
-                )
+            required=['folder_path'],
+            properties=dict(
+                folder_path=dict(type='string')
             )
         )
 

--- a/buzsaki_lab_to_nwb/yuta_code/yutapositiondatainterface.py
+++ b/buzsaki_lab_to_nwb/yuta_code/yutapositiondatainterface.py
@@ -4,9 +4,6 @@ from nwb_conversion_tools.basedatainterface import BaseDataInterface
 from pynwb import NWBFile
 from pynwb.behavior import SpatialSeries
 import os
-
-# TODO: there doesn't seem to be a pypi for to_nwb...
-# we can always have them on our own end locally, but what about users?
 from ..neuroscope import add_position_data
 
 
@@ -14,7 +11,14 @@ class YutaPositionInterface(BaseDataInterface):
 
     @classmethod
     def get_input_schema(cls):
-        return {}
+        return dict(
+            source_data=dict(
+                required=['folder_path'],
+                properties=dict(
+                    folder_path=dict(type='string')
+                )
+            )
+        )
 
     def __init__(self, **input_args):
         super().__init__(**input_args)

--- a/setup.py
+++ b/setup.py
@@ -15,5 +15,5 @@ setup(name='buzsaki_lab_to_nwb',
       packages=find_packages(),
       include_package_data=True,
       install_requires=['matplotlib', 'cycler', 'scipy', 'numpy', 'jupyter', 'xlrd',
-                        'h5py', 'pynwb', 'spikeextractors', 'lxml', 'typing', 'nwbn-conversion-tools'],
+                        'h5py', 'pynwb', 'spikeextractors', 'lxml', 'typing']#, 'nwbn-conversion-tools'],
       )


### PR DESCRIPTION
A series of changes to reflect the current state of [dev_baseconverter ](https://github.com/catalystneuro/nwb-conversion-tools/tree/dev_baseconverter) branch of nwb-conversion-tools.

This mainly requires the block 'source_data' to be appended as an outer key to several data interfaces; also had to update the input schemas for manually defined data interface classes since the reliant functions do not have retrievable docvals like those in SpikeExtractors.

Also adjusted some of the file locations to the way they are on smaug.