### PR TITLE
generalized neuroscope waveform interface; updated Grosmark to v0.6.3

### DIFF
--- a/buzsaki_lab_to_nwb/grosmark_code/convert_grosmark.py
+++ b/buzsaki_lab_to_nwb/grosmark_code/convert_grosmark.py
@@ -1,6 +1,7 @@
 """Authors: Cody Baker and Ben Dichter."""
-from buzsaki_lab_to_nwb import GrosmarkNWBConverter
 from pathlib import Path
+
+from buzsaki_lab_to_nwb import GrosmarkNWBConverter
 
 base_path = Path("D:/BuzsakiData/GrosmarkAD")
 mice_names = ["Achilles", "Buddy", "Cicero", "Gatsby"]
@@ -8,20 +9,22 @@ mice_names = ["Achilles", "Buddy", "Cicero", "Gatsby"]
 convert_sessions = [session for mouse_name in mice_names for session in (base_path / Path(mouse_name)).iterdir()]
 
 experimenter = "Andres Grosmark"
-paper_descr = "This data set is composed of eight bilateral silicon-probe multi-cellular electrophysiological "
-"recordings performed on four male Long-Evans rats in the Buzsáki lab at NYU. These recordings were "
-"performed to assess the effect of novel spatial learning on hippocampal CA1 neural firing and LFP "
-"patterns in naïve animals. Each session consisted of a long (~4 hour) PRE rest/sleep epoch home-cage "
-"recordings performed in a familiar room, followed by a Novel MAZE running epoch (~45 minutes) in which "
-"the animals were transferred to a novel room, and water-rewarded to run on a novel maze. These mazes "
-"were either A) a wooden 1.6m linear platform, B) a wooden 1m diameter circular platform or C) a 2m "
-"metal linear platform. Animals were rewarded either at both ends of the linear platform, or at a "
-"predetermined location on the circular platform. The animal was gently encouraged to run "
-"unidirectionally on the circular platform. After the MAZE epochs the animals were transferred back "
-"to their home-cage in the familiar room where a long (~4 hour) POST rest/sleep was recorded. All eight "
-"sessions were concatenated from the PRE, MAZE, and POST recording epochs. In addition to hippocampal "
-"electrophysiological recordings, neck EMG and head-mounted accelerometer signals were recorded, and the "
-"animal’s position during MAZE running epochs was tracked via head-mounted LEDs."
+paper_descr = (
+    "This data set is composed of eight bilateral silicon-probe multi-cellular electrophysiological "
+    "recordings performed on four male Long-Evans rats in the Buzsáki lab at NYU. These recordings were "
+    "performed to assess the effect of novel spatial learning on hippocampal CA1 neural firing and LFP "
+    "patterns in naïve animals. Each session consisted of a long (~4 hour) PRE rest/sleep epoch home-cage "
+    "recordings performed in a familiar room, followed by a Novel MAZE running epoch (~45 minutes) in which "
+    "the animals were transferred to a novel room, and water-rewarded to run on a novel maze. These mazes "
+    "were either A) a wooden 1.6m linear platform, B) a wooden 1m diameter circular platform or C) a 2m "
+    "metal linear platform. Animals were rewarded either at both ends of the linear platform, or at a "
+    "predetermined location on the circular platform. The animal was gently encouraged to run "
+    "unidirectionally on the circular platform. After the MAZE epochs the animals were transferred back "
+    "to their home-cage in the familiar room where a long (~4 hour) POST rest/sleep was recorded. All eight "
+    "sessions were concatenated from the PRE, MAZE, and POST recording epochs. In addition to hippocampal "
+    "electrophysiological recordings, neck EMG and head-mounted accelerometer signals were recorded, and the "
+    "animal’s position during MAZE running epochs was tracked via head-mounted LEDs."
+)
 paper_info = [
     "Grosmark, A.D., and Buzsáki, G. (2016). "
     "Diversity in neural firing dynamics supports both rigid and learned hippocampal sequences. "
@@ -31,9 +34,11 @@ paper_info = [
     "Sci. Rep. 6, 32193."
 ]
 
-device_descr = "Silicon electrodes on Ampliplex probe; all probes were implanted parallel to the "
-"septo-temporal axis of the dorsal hippocampus. First eight shanks pertain to CA1 left hemisphere, "
-"second eight pertain to CA1 right hemisphere."
+device_descr = (
+    "Silicon electrodes on Ampliplex probe; all probes were implanted parallel to the "
+    "septo-temporal axis of the dorsal hippocampus. First eight shanks pertain to CA1 left hemisphere, "
+    "second eight pertain to CA1 right hemisphere."
+)
 bad_electrodes = dict(
     Buddy_06272013=[24, 27, 58],
     Gatsby_08022013=[],
@@ -76,13 +81,6 @@ for session_path in convert_sessions:
         session_description=paper_descr,
         related_publications=paper_info
     )
-    metadata['Subject'].update(
-        species="Rattus norvegicus domestica - Long Evans",
-        genotype="Wild type",
-        sex="male",
-        weight="250-350g"
-    )
-    # No age information reported in either publication, not available on dataset or site
     metadata['Ecephys']['Device'][0].update(description=device_descr)
     metadata['Ecephys']['Electrodes'].append(
         dict(
@@ -101,10 +99,3 @@ for session_path in convert_sessions:
         conversion_options=conversion_options,
         overwrite=True
     )
-    # nwbfile = grosmark_converter.run_conversion(
-    #     nwbfile_path=str(nwbfile_path),
-    #     metadata=metadata,
-    #     conversion_options=conversion_options,
-    #     overwrite=True,
-    #     save_to_file=False
-    # )

--- a/buzsaki_lab_to_nwb/grosmark_code/grosmarkbehaviordatainterface.py
+++ b/buzsaki_lab_to_nwb/grosmark_code/grosmarkbehaviordatainterface.py
@@ -18,11 +18,9 @@ class GrosmarkBehaviorInterface(BaseDataInterface):
 
     @classmethod
     def get_source_schema(cls):
-        """Return subset of json schema for informing the NWBConverter of expepcted input arguments."""
         return dict(properties=dict(folder_path=dict(type="string")))
 
     def run_conversion(self, nwbfile: NWBFile, metadata: dict):
-        """Convert the behavioral portion of a particular session of the GrosmarkAD dataset."""
         session_path = Path(self.source_data['folder_path'])
         session_id = session_path.stem
 

--- a/buzsaki_lab_to_nwb/grosmark_code/grosmarknwbconverter.py
+++ b/buzsaki_lab_to_nwb/grosmark_code/grosmarknwbconverter.py
@@ -32,7 +32,10 @@ class GrosmarkNWBConverter(NWBConverter):
         )
         metadata.update(
             Subject=dict(
-                species="Mus musculus"
+                species="Rattus norvegicus domestica - Long Evans",
+                genotype="Wild type",
+                sex="male",
+                weight="250-350g"
             )
         )
 


### PR DESCRIPTION
@bendichter 

1) updated all of Grosmark converter and interface codes for nwb-conversion-tools v0.6.3
2) generalized the waveform interface for all neuroscope files (.spk format); previously this was a part of experiment specific LFP (which is also now generalized per nwb-conversion-tools)
3) updated device description and LFP conversion factor to Ampliplex
4) generally refactored for improved performance and code reduction