### PR TITLE
Synchronize pip and conda install methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@ $ git clone https://github.com/catalystneuro/buzsaki-lab-to-nwb
 $ pip install -e buzsaki-lab-to-nwb
 ```
 
+Alternatively, to clone the repository and set up a conda environment, do:
+```
+$ git clone https://github.com/catalystneuro/buzsaki-lab-to-nwb
+$ cd nwb-conversion-tools
+$ conda env create --file make_env.yml
+$ conda activate buzsaki-lab-to-nwb-env
+$ pip install .
+```
+
 # Workflow
 Here is a basic description of the standard conversion pipeline for this project.
 

--- a/make_env.yml
+++ b/make_env.yml
@@ -1,21 +1,13 @@
-name: convert_to_nwb
+name: buzsaki-lab-to-nwb-env
 channels:
 - defaults
 - anaconda
 - conda-forge
 dependencies:
-- python=3.7
+- python==3.7
 - ipython
+- pandas>=1.2.3
 - pip
-- numpy
-- scipy
-- jupyter
-- matplotlib
-- cycler
-- h5py
-- pynwb
-- hdmf
 - pip:
-  - ndx-grayscalevolume
-  - git+https://github.com/NeurodataWithoutBorders/nwbn-conversion-tools
+  - -r requirements.txt
   - -e .

--- a/make_env.yml
+++ b/make_env.yml
@@ -4,7 +4,7 @@ channels:
 - anaconda
 - conda-forge
 dependencies:
-- python==3.7
+- python>=3.7
 - ipython
 - pandas>=1.2.3
 - pip

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,8 @@
-
-pynwb==1.4.0
-tqdm==4.60.0
+pynwb>=1.4.0  
+tqdm>=4.60.0
 numpy==1.19.3
-pandas==1.2.3
-scipy==1.4.1
+pandas>=1.2.3
+scipy>=1.4.1
 h5py==2.10.0
 hdf5storage==0.1.18
 PyYAML==5.4
@@ -11,7 +10,7 @@ jsonschema==3.2.0
 psutil==5.8.0
 lxml==4.6.5
 spikeextractors==0.9.7
-neo==0.9.0
+neo==0.9.0  # it is 0.9.0 in nwb-conversion-tools
 mat4py==0.5.0
 mat73==0.52
 nwb-conversion-tools @ git+https://github.com/catalystneuro/nwb-conversion-tools.git@55dc42853e3204b560f8e44b149ab0508e36852f

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
-pynwb>=1.4.0  
-tqdm>=4.60.0
+
+pynwb==1.4.0
+tqdm==4.60.0
 numpy==1.19.3
-pandas>=1.2.3
-scipy>=1.4.1
+pandas==1.2.3
+scipy==1.4.1
 h5py==2.10.0
 hdf5storage==0.1.18
 PyYAML==5.4
@@ -10,7 +11,7 @@ jsonschema==3.2.0
 psutil==5.8.0
 lxml==4.6.5
 spikeextractors==0.9.7
-neo==0.9.0  # it is 0.9.0 in nwb-conversion-tools
+neo==0.9.0
 mat4py==0.5.0
 mat73==0.52
 nwb-conversion-tools @ git+https://github.com/catalystneuro/nwb-conversion-tools.git@55dc42853e3204b560f8e44b149ab0508e36852f

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,17 +1,5 @@
-
-pynwb==1.4.0
-tqdm==4.60.0
-numpy>=1.21.0
-pandas==1.2.3
-scipy==1.4.1
-h5py==2.10.0
-hdf5storage==0.1.18
-PyYAML==5.4
-jsonschema==3.2.0
-psutil==5.8.0
-lxml==4.6.5
-spikeextractors==0.9.7
-neo==0.9.0
 mat4py==0.5.0
 mat73==0.52
-nwb-conversion-tools @ git+https://github.com/catalystneuro/nwb-conversion-tools.git@55dc42853e3204b560f8e44b149ab0508e36852f
+hdf5storage>=0.1.18
+nwb-conversion-tools>=0.9.1
+spikeextractors>=0.9.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ numpy>=1.21.0
 pandas==1.2.3
 scipy==1.4.1
 h5py==2.10.0
-==0.1.18
+numpy==0.1.18
 PyYAML==5.4
 jsonschema==3.2.0
 psutil==5.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ numpy>=1.21.0
 pandas==1.2.3
 scipy==1.4.1
 h5py==2.10.0
-numpy==0.1.18
+hdf5storage==0.1.18
 PyYAML==5.4
 jsonschema==3.2.0
 psutil==5.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 
 pynwb==1.4.0
 tqdm==4.60.0
-numpy==1.19.3
+numpy>=1.21.0
 pandas==1.2.3
 scipy==1.4.1
 h5py==2.10.0
-hdf5storage==0.1.18
+==0.1.18
 PyYAML==5.4
 jsonschema==3.2.0
 psutil==5.8.0


### PR DESCRIPTION
Fixes #40 

# Description
This should allow the user to install the environment using conda. I also modified the `README.md ` file to indicate how to create the environment install with conda. I tested this on dandihub and it seems to be working. As you can see in the diff of `make_env.yml` file (conda) it now tracks the `requirements.txt` (pip).  That is, if we modify the `requirements.txt` file the conda environment will track those changes without further modifications. The only exception is the pandas library that had to be written explicitly in the conda file. There is some version compatibility issue that I could not identify but I hope I can solve after some discussion of the issues in the following section.

## Questions and discussion
1) As things stand we require a very specific snapshot of `nwb-conversiont-tools` in the `requirements.txt` file:
https://github.com/catalystneuro/buzsaki-lab-to-nwb/blob/8e139f8f617599a8c043ea32ce40ea6fd4493e05/requirements.txt#L17
Why is this? can we just install the latest available release or the latest available version? maybe we should document this choice?
2) The requirements of this repo and the ones of `nwb-conversion-tools` require sometimes the same package but not the same version. For example, we require `numpy==1.19.3` here but in `nwb-conversion-tools` we require `numpy>=1.21.0`.  I hightliht some of these differences in the code revision below.
3) Out of curiosity, why do we have python=3.7 for both this repo and `nwb-conversion-tools`, is there a package that does not work in newer versions or is it out of caution?


