### PR TITLE
Added check for empty units

### DIFF
--- a/buzsaki_lab_to_nwb/tingley_code_septal/convert_tingley_septal.py
+++ b/buzsaki_lab_to_nwb/tingley_code_septal/convert_tingley_septal.py
@@ -10,10 +10,10 @@ from buzsaki_lab_to_nwb import TingleySeptalNWBConverter
 stub_test = True
 conversion_factor = 0.195  # Intan
 metadata_path = Path("/home/jovyan/development/buzsaki-lab-to-nwb/buzsaki_lab_to_nwb/tingley_code_septal/metadata.yml")
-#metadata_path = "/home/heberto/development/buzsaki-lab-to-nwb/buzsaki_lab_to_nwb/tingley_code_septal/metadata.yml"
+# metadata_path = "/home/heberto/development/buzsaki-lab-to-nwb/buzsaki_lab_to_nwb/tingley_code_septal/metadata.yml"
 
 data_path = Path("/shared/catalystneuro/Buzsaki/TingleyD/")
-#data_path = Path("/home/heberto/globus_data/Buzsaki/TingleyD/")
+# data_path = Path("/home/heberto/globus_data/Buzsaki/TingleyD/")
 
 # nwb_output_path = Path("/shared/catalystneuro/Buzsaki/TingleyD/nwbfiles")
 if stub_test:
@@ -42,7 +42,7 @@ session_path_list = [
     if session.is_dir() and session.name not in invalid_session
 ]
 
-#session_path_list = [Path("/shared/catalystneuro/Buzsaki/TingleyD/DT7/20170409_1152um_1152um_170409_115803")]
+# session_path_list = [Path("/shared/catalystneuro/Buzsaki/TingleyD/DT7/20170409_1152um_1152um_170409_115803")]
 
 counter = 0
 for session_path in session_path_list:

--- a/buzsaki_lab_to_nwb/tingley_code_septal/convert_tingley_septal.py
+++ b/buzsaki_lab_to_nwb/tingley_code_septal/convert_tingley_septal.py
@@ -9,15 +9,16 @@ from buzsaki_lab_to_nwb import TingleySeptalNWBConverter
 
 stub_test = True
 conversion_factor = 0.195  # Intan
-# metadata_path = Path("/home/jovyan/development/buzsaki-lab-to-nwb/buzsaki_lab_to_nwb/tingley_code_septal/metadata.yml")
-metadata_path = "/home/heberto/development/buzsaki-lab-to-nwb/buzsaki_lab_to_nwb/tingley_code_septal/metadata.yml"
+metadata_path = Path("/home/jovyan/development/buzsaki-lab-to-nwb/buzsaki_lab_to_nwb/tingley_code_septal/metadata.yml")
+#metadata_path = "/home/heberto/development/buzsaki-lab-to-nwb/buzsaki_lab_to_nwb/tingley_code_septal/metadata.yml"
 
-# data_path = Path("/shared/catalystneuro/Buzsaki/TingleyD/")
-data_path = Path("/home/heberto/globus_data/Buzsaki/TingleyD/")
+data_path = Path("/shared/catalystneuro/Buzsaki/TingleyD/")
+#data_path = Path("/home/heberto/globus_data/Buzsaki/TingleyD/")
 
 # nwb_output_path = Path("/shared/catalystneuro/Buzsaki/TingleyD/nwbfiles")
 if stub_test:
-    nwb_output_path = Path("/home/heberto/nwb_stub")
+    nwb_output_path = Path("/home/jovyan/nwb_stub")
+    # nwb_output_path = Path("/home/heberto/nwb_stub")
 else:
     nwb_output_path = Path("/home/heberto/nwb")
 nwb_output_path.mkdir(exist_ok=True)
@@ -41,7 +42,7 @@ session_path_list = [
     if session.is_dir() and session.name not in invalid_session
 ]
 
-# session_path_list = [Path("/shared/catalystneuro/Buzsaki/TingleyD/DT8/20170220_216um_1944um_170220_192456")]
+#session_path_list = [Path("/shared/catalystneuro/Buzsaki/TingleyD/DT7/20170409_1152um_1152um_170409_115803")]
 
 counter = 0
 for session_path in session_path_list:

--- a/buzsaki_lab_to_nwb/tingley_code_septal/tingleyseptalbehaviorinterface.py
+++ b/buzsaki_lab_to_nwb/tingley_code_septal/tingleyseptalbehaviorinterface.py
@@ -96,7 +96,7 @@ class TingleySeptalBehaviorInterface(BaseDataInterface):
 
             spatial_series_object = SpatialSeries(
                 name="error_per_marker",
-                description="Error per marker.",
+                description="Estimated error for marker tracking from optitrack system.",
                 data=H5DataIO(error_data, compression="gzip"),
                 reference_frame="unknown",
                 conversion=conversion,
@@ -116,7 +116,7 @@ class TingleySeptalBehaviorInterface(BaseDataInterface):
             ]
             orientation_data = np.array(orientation_data)[..., 0]
 
-            compass_obj = CompassDirection(name=f"allocentric_frame_analysis")
+            compass_obj = CompassDirection(name=f"allocentric_frame_tracking")
 
             spatial_series_object = SpatialSeries(
                 name="orientation",

--- a/buzsaki_lab_to_nwb/tingley_code_septal/tingleyseptalbehaviorinterface.py
+++ b/buzsaki_lab_to_nwb/tingley_code_septal/tingleyseptalbehaviorinterface.py
@@ -74,7 +74,7 @@ class TingleySeptalBehaviorInterface(BaseDataInterface):
         description = behavior_mat.get("description", "generic_position_tracking").replace("/", "-")
         rotation_type = behavior_mat.get("rotationType", "non_specified")
 
-        pos_obj = Position(name=f"{description}_track".replace(" ", "_"))
+        pos_obj = Position(name=f"{description}_task".replace(" ", "_"))
 
         spatial_series_object = SpatialSeries(
             name="position",

--- a/buzsaki_lab_to_nwb/tingley_code_septal/tingleyseptalbehaviorinterface.py
+++ b/buzsaki_lab_to_nwb/tingley_code_septal/tingleyseptalbehaviorinterface.py
@@ -74,7 +74,7 @@ class TingleySeptalBehaviorInterface(BaseDataInterface):
         description = behavior_mat.get("description", "generic_position_tracking").replace("/", "-")
         rotation_type = behavior_mat.get("rotationType", "non_specified")
 
-        pos_obj = Position(name=f"{description}".replace(" ", "_"))
+        pos_obj = Position(name=f"{description}_track".replace(" ", "_"))
 
         spatial_series_object = SpatialSeries(
             name="position",

--- a/buzsaki_lab_to_nwb/tingley_code_septal/tingleyseptalbehaviorinterface.py
+++ b/buzsaki_lab_to_nwb/tingley_code_septal/tingleyseptalbehaviorinterface.py
@@ -116,11 +116,7 @@ class TingleySeptalBehaviorInterface(BaseDataInterface):
             ]
             orientation_data = np.array(orientation_data)[..., 0]
 
-            module_name = "orientation"
-            module_description = "Contains behavioral data concerning orientation."
-            processing_module = get_module(nwbfile=nwbfile, name=module_name, description=module_description)
-
-            compass_obj = CompassDirection(name=f"route_centric")
+            compass_obj = CompassDirection(name=f"allocentric_frame_analysis")
 
             spatial_series_object = SpatialSeries(
                 name="orientation",

--- a/buzsaki_lab_to_nwb/tingley_code_septal/tingleyseptalbehaviorinterface.py
+++ b/buzsaki_lab_to_nwb/tingley_code_septal/tingleyseptalbehaviorinterface.py
@@ -63,7 +63,7 @@ class TingleySeptalBehaviorInterface(BaseDataInterface):
         pos_data = [[x, y, z] for (x, y, z) in zip(position["x"], position["y"], position["y"])]
         pos_data = np.array(pos_data)[..., 0]
 
-        unit = behavior_mat.get("units", None)
+        unit = behavior_mat.get("units", "")
 
         if unit == ["m", "meter", "meters"]:
             conversion = 1.0


### PR DESCRIPTION
Short PR to add a check for empty units in the behavioral interface. This is because the spatial series in `pynwb` expects string by default and produces an assertion error with the None type.