### PR TITLE
Log project structural information

### DIFF
--- a/buzsaki_lab_to_nwb/huszar_hippocampus_dynamics/files_documentation.ipynb
+++ b/buzsaki_lab_to_nwb/huszar_hippocampus_dynamics/files_documentation.ipynb
@@ -45,7 +45,7 @@
     {
      "data": {
       "text/plain": [
-       "[PosixPath('/Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.cell_metrics.cellinfo.mat'),\n",
+       "[PosixPath('/Volumes/neurodata/buzsaki/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.cell_metrics.cellinfo.mat'),\n",
        " PosixPath('/Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/._e13_16f1_210302.cell_metrics.cellinfo.mat'),\n",
        " PosixPath('/Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.ripples.events.mat'),\n",
        " PosixPath('/Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/._e13_16f1_210302.ripples.events.mat'),\n",

--- a/buzsaki_lab_to_nwb/huszar_hippocampus_dynamics/files_documentation.ipynb
+++ b/buzsaki_lab_to_nwb/huszar_hippocampus_dynamics/files_documentation.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -39,29 +39,38 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[PosixPath('/home/heberto/buzaki/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat'),\n",
-       " PosixPath('/home/heberto/buzaki/e13_16f1_210302/e13_16f1_210302.ripples.events.mat'),\n",
-       " PosixPath('/home/heberto/buzaki/e13_16f1_210302/e13_16f1_210302.cell_metrics.cellinfo.mat'),\n",
-       " PosixPath('/home/heberto/buzaki/e13_16f1_210302/chanMap.mat'),\n",
-       " PosixPath('/home/heberto/buzaki/e13_16f1_210302/e13_16f1_210302.spikes.cellinfo.mat'),\n",
-       " PosixPath('/home/heberto/buzaki/e13_16f1_210302/e13_16f1_210302.Behavior.mat'),\n",
-       " PosixPath('/home/heberto/buzaki/e13_16f1_210302/e13_16f1_210302.mono_res.cellinfo.mat'),\n",
-       " PosixPath('/home/heberto/buzaki/e13_16f1_210302/e13_16f1_210302.session.mat')]"
+       "[PosixPath('/Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.cell_metrics.cellinfo.mat'),\n",
+       " PosixPath('/Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/._e13_16f1_210302.cell_metrics.cellinfo.mat'),\n",
+       " PosixPath('/Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.ripples.events.mat'),\n",
+       " PosixPath('/Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/._e13_16f1_210302.ripples.events.mat'),\n",
+       " PosixPath('/Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.spikes.cellinfo.mat'),\n",
+       " PosixPath('/Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/._e13_16f1_210302.spikes.cellinfo.mat'),\n",
+       " PosixPath('/Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.mono_res.cellinfo.mat'),\n",
+       " PosixPath('/Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/._e13_16f1_210302.mono_res.cellinfo.mat'),\n",
+       " PosixPath('/Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat'),\n",
+       " PosixPath('/Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/._e13_16f1_210302.SleepState.states.mat'),\n",
+       " PosixPath('/Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.Behavior.mat'),\n",
+       " PosixPath('/Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/._e13_16f1_210302.Behavior.mat'),\n",
+       " PosixPath('/Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.session.mat'),\n",
+       " PosixPath('/Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/._e13_16f1_210302.session.mat'),\n",
+       " PosixPath('/Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/chanMap.mat'),\n",
+       " PosixPath('/Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/._chanMap.mat')]"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "session_path = Path(\"/home/heberto/buzaki/e13_16f1_210302/\")\n",
+    "project_root = Path(\"/Volumes/neurodata/buzaki/HuszarR/HuszarR\")\n",
+    "session_path = Path(project_root, \"optotagCA1/e13/e13_16f1/e13_16f1_210302\")\n",
     "session_files_path_list = list(session_path.iterdir())\n",
     "session_files_path_list"
    ]
@@ -130,7 +139,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -164,7 +173,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -232,7 +241,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -248,7 +257,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -286,7 +295,7 @@
        "        [15811, 15886]], dtype=uint16)}"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -297,7 +306,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -317,7 +326,7 @@
        "       [15887, 21006]], dtype=uint16)"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -345,7 +354,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -354,7 +363,7 @@
        "True"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -366,7 +375,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -396,7 +405,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -405,7 +414,7 @@
        "True"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -418,7 +427,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -447,7 +456,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -456,7 +465,7 @@
        "False"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -469,7 +478,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -496,7 +505,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -505,7 +514,7 @@
        "True"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -518,7 +527,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -550,27 +559,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/home/heberto/miniconda3/envs/neuroconv_env/lib/python3.10/site-packages/tqdm/auto.py:22: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "/opt/anaconda3/envs/conversion/lib/python3.11/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
       "  from .autonotebook import tqdm as notebook_tqdm\n"
      ]
     },
     {
      "ename": "AssertionError",
-     "evalue": "No e13_16f1_210302.sessionInfo.mat file found in the folder!",
+     "evalue": "To use the CellExplorerSortingExtractor install scipy and hdf5storage: \n\n pip install scipy  hdf5storage",
      "output_type": "error",
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
       "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[16], line 4\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[39mfrom\u001b[39;00m \u001b[39mspikeinterface\u001b[39;00m\u001b[39m.\u001b[39;00m\u001b[39mextractors\u001b[39;00m \u001b[39mimport\u001b[39;00m CellExplorerSortingExtractor\n\u001b[1;32m      3\u001b[0m file_path \u001b[39m=\u001b[39m session_files_path_list[\u001b[39m0\u001b[39m]\u001b[39m.\u001b[39mparent \u001b[39m/\u001b[39m \u001b[39m\"\u001b[39m\u001b[39me13_16f1_210302.spikes.cellinfo.mat\u001b[39m\u001b[39m\"\u001b[39m\n\u001b[0;32m----> 4\u001b[0m extractor \u001b[39m=\u001b[39m CellExplorerSortingExtractor(file_path)\n",
-      "File \u001b[0;32m~/development/spikeinterface/src/spikeinterface/extractors/cellexplorersortingextractor.py:54\u001b[0m, in \u001b[0;36mCellExplorerSortingExtractor.__init__\u001b[0;34m(self, spikes_matfile_path, session_info_matfile_path, sampling_frequency)\u001b[0m\n\u001b[1;32m     52\u001b[0m     session_info_matfile_path \u001b[39m=\u001b[39m folder_path \u001b[39m/\u001b[39m \u001b[39mf\u001b[39m\u001b[39m\"\u001b[39m\u001b[39m{\u001b[39;00msorting_id\u001b[39m}\u001b[39;00m\u001b[39m.sessionInfo.mat\u001b[39m\u001b[39m\"\u001b[39m\n\u001b[1;32m     53\u001b[0m session_info_matfile_path \u001b[39m=\u001b[39m Path(session_info_matfile_path)\n\u001b[0;32m---> 54\u001b[0m \u001b[39massert\u001b[39;00m (\n\u001b[1;32m     55\u001b[0m     (session_info_matfile_path)\u001b[39m.\u001b[39mis_file()\n\u001b[1;32m     56\u001b[0m ), \u001b[39mf\u001b[39m\u001b[39m\"\u001b[39m\u001b[39mNo \u001b[39m\u001b[39m{\u001b[39;00msorting_id\u001b[39m}\u001b[39;00m\u001b[39m.sessionInfo.mat file found in the folder!\u001b[39m\u001b[39m\"\u001b[39m \n\u001b[1;32m     58\u001b[0m \u001b[39mtry\u001b[39;00m:\n\u001b[1;32m     59\u001b[0m     session_info_mat \u001b[39m=\u001b[39m scipy\u001b[39m.\u001b[39mio\u001b[39m.\u001b[39mloadmat(file_name\u001b[39m=\u001b[39m\u001b[39mstr\u001b[39m(session_info_matfile_path))\n",
-      "\u001b[0;31mAssertionError\u001b[0m: No e13_16f1_210302.sessionInfo.mat file found in the folder!"
+      "Cell \u001b[0;32mIn[19], line 4\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[39mfrom\u001b[39;00m \u001b[39mspikeinterface\u001b[39;00m\u001b[39m.\u001b[39;00m\u001b[39mextractors\u001b[39;00m \u001b[39mimport\u001b[39;00m CellExplorerSortingExtractor\n\u001b[1;32m      3\u001b[0m file_path \u001b[39m=\u001b[39m session_files_path_list[\u001b[39m0\u001b[39m]\u001b[39m.\u001b[39mparent \u001b[39m/\u001b[39m \u001b[39m\"\u001b[39m\u001b[39me13_16f1_210302.spikes.cellinfo.mat\u001b[39m\u001b[39m\"\u001b[39m\n\u001b[0;32m----> 4\u001b[0m extractor \u001b[39m=\u001b[39m CellExplorerSortingExtractor(file_path)\n",
+      "File \u001b[0;32m/opt/anaconda3/envs/conversion/lib/python3.11/site-packages/spikeinterface/extractors/cellexplorersortingextractor.py:41\u001b[0m, in \u001b[0;36mCellExplorerSortingExtractor.__init__\u001b[0;34m(self, spikes_matfile_path, session_info_matfile_path, sampling_frequency)\u001b[0m\n\u001b[1;32m     38\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39m__init__\u001b[39m(\u001b[39mself\u001b[39m, spikes_matfile_path: PathType,\n\u001b[1;32m     39\u001b[0m              session_info_matfile_path: OptionalPathType\u001b[39m=\u001b[39m\u001b[39mNone\u001b[39;00m,\n\u001b[1;32m     40\u001b[0m              sampling_frequency: Optional[\u001b[39mfloat\u001b[39m] \u001b[39m=\u001b[39m \u001b[39mNone\u001b[39;00m):\n\u001b[0;32m---> 41\u001b[0m     \u001b[39massert\u001b[39;00m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39minstalled, \u001b[39mself\u001b[39m\u001b[39m.\u001b[39minstallation_mesg\n\u001b[1;32m     43\u001b[0m     spikes_matfile_path \u001b[39m=\u001b[39m Path(spikes_matfile_path)\n\u001b[1;32m     44\u001b[0m     \u001b[39massert\u001b[39;00m (\n\u001b[1;32m     45\u001b[0m         spikes_matfile_path\u001b[39m.\u001b[39mis_file()\n\u001b[1;32m     46\u001b[0m     ), \u001b[39mf\u001b[39m\u001b[39m\"\u001b[39m\u001b[39mThe spikes_matfile_path (\u001b[39m\u001b[39m{\u001b[39;00mspikes_matfile_path\u001b[39m}\u001b[39;00m\u001b[39m) must exist!\u001b[39m\u001b[39m\"\u001b[39m\n",
+      "\u001b[0;31mAssertionError\u001b[0m: To use the CellExplorerSortingExtractor install scipy and hdf5storage: \n\n pip install scipy  hdf5storage"
      ]
     }
    ],
@@ -613,7 +622,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -628,9 +637,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "dict_keys(['ids', 'ts', 'times', 'cluID', 'maxWaveformCh', 'maxWaveformCh1', 'phy_amp', 'total', 'amplitudes', 'basename', 'numcells', 'UID', 'sr', 'shankID', 'rawWaveform', 'filtWaveform', 'rawWaveform_all', 'rawWaveform_std', 'filtWaveform_all', 'filtWaveform_std', 'timeWaveform', 'timeWaveform_all', 'peakVoltage', 'channels_all', 'peakVoltage_sorted', 'maxWaveform_all', 'peakVoltage_expFitLengthConstant', 'processinginfo'])"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "spikes = mat_file[\"spikes\"]\n",
     "spikes.keys()"
@@ -638,9 +658,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(30000,\n",
+       " (135,),\n",
+       " (135,),\n",
+       " (135,),\n",
+       " array([1, 2, 3], dtype=uint8),\n",
+       " array([ 119, 1162, 1167], dtype=uint16),\n",
+       " array([ 68.71136667, 255.81043333, 256.2958    ]))"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "sampling_rate = spikes[\"sr\"]\n",
     "cluster_id = spikes[\"cluID\"]\n",
@@ -660,7 +697,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -673,9 +710,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "dict_keys(['ids', 'ts', 'times', 'cluID', 'maxWaveformCh', 'maxWaveformCh1', 'phy_amp', 'total', 'amplitudes', 'basename', 'numcells', 'UID', 'sr', 'shankID', 'rawWaveform', 'filtWaveform', 'rawWaveform_all', 'rawWaveform_std', 'filtWaveform_all', 'filtWaveform_std', 'timeWaveform', 'timeWaveform_all', 'peakVoltage', 'channels_all', 'peakVoltage_sorted', 'maxWaveform_all', 'peakVoltage_expFitLengthConstant', 'processinginfo'])"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "spikes = mat_file[\"spikes\"]\n",
     "spikes.keys()"
@@ -683,9 +731,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(30000,\n",
+       " (135,),\n",
+       " (135,),\n",
+       " (135,),\n",
+       " array([1, 2, 3], dtype=uint8),\n",
+       " array([ 119, 1162, 1167], dtype=uint16),\n",
+       " array([ 68.71136667, 255.81043333, 256.2958    ]))"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "sampling_rate = spikes[\"sr\"]\n",
     "cluster_id = spikes[\"cluID\"]\n",
@@ -705,7 +770,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -719,9 +784,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "dict_keys(['ids', 'ts', 'times', 'cluID', 'maxWaveformCh', 'maxWaveformCh1', 'phy_amp', 'total', 'amplitudes', 'basename', 'numcells', 'UID', 'sr', 'shankID', 'rawWaveform', 'filtWaveform', 'rawWaveform_all', 'rawWaveform_std', 'filtWaveform_all', 'filtWaveform_std', 'timeWaveform', 'timeWaveform_all', 'peakVoltage', 'channels_all', 'peakVoltage_sorted', 'maxWaveform_all', 'peakVoltage_expFitLengthConstant', 'processinginfo'])"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "spikes = mat_file[\"spikes\"]\n",
     "spikes.keys()"
@@ -729,9 +805,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 28,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(30000,\n",
+       " (135,),\n",
+       " (135,),\n",
+       " (135,),\n",
+       " array([1, 2, 3], dtype=uint8),\n",
+       " array([ 119, 1162, 1167], dtype=uint16),\n",
+       " array([ 68.71136667, 255.81043333, 256.2958    ]))"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "sampling_rate = spikes[\"sr\"]\n",
     "cluster_id = spikes[\"cluID\"]\n",
@@ -742,11 +835,372 @@
    ]
   },
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Check for Consistency across Files\n",
+    "The following code will loop over all the folders contained in a given directory and track where they occur. This will give us an indication of the file *structure* consistency—which we can also use to detect whether the data in those files is homogeneous as well."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 49,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "import os\n",
+    "from tqdm.notebook import tqdm\n",
+    "\n",
+    "def aggregate_file_info(parent_folder, func, aggregator=None):\n",
+    "    \n",
+    "    if aggregator is None:\n",
+    "       aggregator = []\n",
+    "\n",
+    "\n",
+    "    naming_conventions = {}\n",
+    "    for root, dirs, files in tqdm(os.walk(parent_folder)):\n",
+    "        for file in tqdm(files):\n",
+    "            filename, ext = os.path.splitext(file)\n",
+    "            if filename and filename[0] != '.':\n",
+    "                split_path = filename.split('.')\n",
+    "                naming_convention = '.'.join(split_path[1:]) if len(split_path) > 1 else filename # Remove the '.' character\n",
+    "                if naming_convention not in naming_conventions:\n",
+    "                    naming_conventions[naming_convention] = [] if (isinstance(aggregator, list)) else {} # Use aggregator type as a base\n",
+    "                \n",
+    "                info = func(\n",
+    "                    file = file,\n",
+    "                    naming_convention = naming_convention,\n",
+    "                    root = root,\n",
+    "                    parent_folder = parent_folder\n",
+    "                )\n",
+    "\n",
+    "                if isinstance(naming_conventions[naming_convention], list):\n",
+    "                    naming_conventions[naming_convention].append(info)\n",
+    "\n",
+    "                else: \n",
+    "                    naming_conventions[naming_convention][file] = info\n",
+    "                    \n",
+    "    return naming_conventions\n",
+    "\n",
+    "def get_file_name(root, parent_folder, **kwargs):\n",
+    "    return os.path.relpath(root, parent_folder)\n",
+    "\n",
+    "def count_file_naming_conventions(parent_folder):\n",
+    "    return aggregate_file_info(parent_folder, get_file_name)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Organize Project Structure by File Types"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "project_json_directory = Path.cwd() / \"_json_files\" / \"project\"\n",
+    "project_json_directory.mkdir(exist_ok=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "structure = count_file_naming_conventions(project_root)\n",
+    "with open(json_directory / 'project' / 'structure.json', 'w') as f:\n",
+    "    f.write(json.dumps(structure, indent=4))"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Check for Missing File Types"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def add_unique_entries(arr1, arr2):\n",
+    "    for item in arr1:\n",
+    "        if item not in arr2:\n",
+    "            arr2.append(item)\n",
+    "\n",
+    "def filter_list(original_list, filter_list):\n",
+    "    return [value for value in original_list if value not in filter_list]\n",
+    "\n",
+    "def check_missing_files(dictionary):\n",
+    "    lengths = {}\n",
+    "    files = []\n",
+    "    for key, value in dictionary.items():\n",
+    "        lengths[key] = len(value)\n",
+    "        add_unique_entries(value, files)\n",
+    "    \n",
+    "    missing = dict()\n",
+    "    for filetype, length in lengths.items():\n",
+    "        if (len(files) != length):\n",
+    "            original_list = dictionary[filetype]\n",
+    "            missing[filetype] = filter_list(files, original_list)\n",
+    "\n",
+    "    if len(missing.values()):\n",
+    "        print('This dataset has some missing files')\n",
+    "        \n",
+    "    return missing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing = check_missing_files(structure)\n",
+    "with open(json_directory / 'project' / 'missing_files.json', 'w') as f:\n",
+    "    f.write(json.dumps(missing, indent=4))"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Aggregate Data from Files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_file_data(file, root, **kwargs):\n",
+    "    filename, ext = os.path.splitext(file_path)\n",
+    "    if (ext == '.mat'):\n",
+    "        mat_file = loadmat_scipy(Path(root, file), simplify_cells=True)\n",
+    "        return build_keys_and_types(mat_file)\n",
+    "\n",
+    "    else:\n",
+    "        print(f'Cannot handle {file} file type')\n",
+    "        return {}\n",
+    "        \n",
+    "def aggregate_data(parent_folder):\n",
+    "    return aggregate_file_info(parent_folder, get_file_data, {})"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Register all the data associated with a project"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
+      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n"
+     ]
+    }
+   ],
+   "source": [
+    "data = aggregate_data(project_root)\n",
+    "project_data_path = json_directory / 'project' / 'data.json'\n",
+    "with open(project_data_path, 'w') as f:\n",
+    "    f.write(json.dumps(data, indent=4))"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Use the saved data to compare across sessions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 61,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "project_data_path = json_directory / 'project' / 'data.json'\n",
+    "\n",
+    "with open(project_data_path) as user_file:\n",
+    "  file_contents = user_file.read()\n",
+    "  \n",
+    "project_data_json = json.loads(file_contents)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 63,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "dict_keys(['e13_16f1_210328.cell_metrics.cellinfo.mat', 'e13_16f1_210302.cell_metrics.cellinfo.mat', 'e13_16f1_210331.cell_metrics.cellinfo.mat', 'e13_16f1_210312.cell_metrics.cellinfo.mat', 'e13_16f1_210319.cell_metrics.cellinfo.mat', 'e13_16f1_210322.cell_metrics.cellinfo.mat', 'e13_16f1_210317.cell_metrics.cellinfo.mat', 'e13_16f1_210314.cell_metrics.cellinfo.mat', 'e13_16f1_210315.cell_metrics.cellinfo.mat'])\n"
+     ]
+    }
+   ],
+   "source": [
+    "def check_consistency(data, user_check_function, base = ''):\n",
+    "    expected_props = set()\n",
+    "    inconsistencies = {}\n",
+    "\n",
+    "    # Loop through objects to discover expected properties\n",
+    "    for k, obj in data.items():\n",
+    "        props = set(obj.keys())\n",
+    "        expected_props = expected_props.union(props)\n",
+    "\n",
+    "    # Check objects for inconsistencies\n",
+    "    registered_nested_properties = set()\n",
+    "    for file, obj in data.items():\n",
+    "\n",
+    "        inconsistent_props = user_check_function(obj, expected_props, base)\n",
+    "        if (inconsistent_props and len(inconsistent_props)):\n",
+    "            inconsistencies[file] = { f'{base}.{key}': message for key, message in inconsistent_props.items() }\n",
+    "            # inconsistencies[file] = [ f'{base}.{key}' if base else key for key, message in inconsistent_props.items() ]\n",
+    "\n",
+    "        else:\n",
+    "            for key in obj.keys():\n",
+    "                if isinstance(obj[key], dict):\n",
+    "                    registered_nested_properties.add(key)\n",
+    "\n",
+    "    if (len(registered_nested_properties)):\n",
+    "        properties = {}\n",
+    "        for key in registered_nested_properties:\n",
+    "            nested_property_object = { file: obj[key] for file, obj in data.items() if obj.get(key) }\n",
+    "            nested_inconsistencies = check_consistency(nested_property_object, user_check_function, f'{base}.{key}' if base else key)\n",
+    "\n",
+    "            if (len(nested_inconsistencies)):\n",
+    "                properties[key] = nested_inconsistencies\n",
+    "\n",
+    "        if (len(properties)): \n",
+    "            \n",
+    "            for key, value in properties.items():\n",
+    "                for file, item in value.items():\n",
+    "                    if (file not in inconsistencies):\n",
+    "                        inconsistencies[file] = {}\n",
+    "\n",
+    "                    inconsistencies[file].update(item) #f'{base}.{item_string}' if base else item_string)\n",
+    "\n",
+    "    return inconsistencies\n",
+    "\n",
+    "\n",
+    "\n",
+    "def check_missing_props(parent, expected_props, base):\n",
+    "        # Check if any properties are missing or have inconsistent values\n",
+    "        props = set(parent.keys())\n",
+    "        \n",
+    "        if props != expected_props:\n",
+    "            missing_props = expected_props - props\n",
+    "\n",
+    "            if missing_props:\n",
+    "                return { key: 'Missing' for key in missing_props }\n",
+    "\n",
+    "\n",
+    "# inconsistencies = { key: check_consistency(data, check_missing_props) for key, data in project_data_json.items() }\n",
+    "\n",
+    "first_key = next(iter(project_data_json))\n",
+    "print(project_data_json[first_key].keys())\n",
+    "inconsistencies = { key: check_consistency(project_data_json[first_key], check_missing_props) for key, data in project_data_json.items() }\n",
+    "\n",
+    "with open(json_directory / 'project' / 'data_inconsistencies.json', 'w') as f:\n",
+    "    f.write(json.dumps( \n",
+    "        { key: data for key, data in inconsistencies.items() if len(data) } , indent=4))\n",
+    "    "
+   ]
   }
  ],
  "metadata": {
@@ -765,7 +1219,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "version": "3.11.3"
   },
   "orig_nbformat": 4
  },


### PR DESCRIPTION
Added some cells in the notebook created for #56 to derive structural information about the project. 

This searches the last folders (e.g session folders) in an arbitrary root folder for their files, then allows you to output information organized by unique file types (e.g. `cell_metrics.cellinfo` from `xxx.cell_metrics.cellinfo.mat`).

Based on this, you can refer to the outputted `_json_files/project/data_inconsistencies.json` file to see which files are missing data that are present in other project files that match its type.  This simply compares the keys between each file's `build_keys_and_types` output between sessions—though this could be extended to validate the consistency of the actual (meta)data values.

> **Note:** The `data.json` file that this depends on takes a while to be generated. However, subsequent code will refer to the saved JSON file so we don't need to rerun this until we change the root scope.

Let me know if there're any changes to the output files that would improve their usefulness—or whether an alternative approach is warranted.