### PR TITLE
Improve Huszar Comparisons

### DIFF
--- a/buzsaki_lab_to_nwb/huszar_hippocampus_dynamics/files_documentation.ipynb
+++ b/buzsaki_lab_to_nwb/huszar_hippocampus_dynamics/files_documentation.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -39,37 +39,37 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[PosixPath('/Volumes/neurodata/buzsaki/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.cell_metrics.cellinfo.mat'),\n",
-       " PosixPath('/Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/._e13_16f1_210302.cell_metrics.cellinfo.mat'),\n",
-       " PosixPath('/Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.ripples.events.mat'),\n",
-       " PosixPath('/Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/._e13_16f1_210302.ripples.events.mat'),\n",
-       " PosixPath('/Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.spikes.cellinfo.mat'),\n",
-       " PosixPath('/Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/._e13_16f1_210302.spikes.cellinfo.mat'),\n",
-       " PosixPath('/Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.mono_res.cellinfo.mat'),\n",
-       " PosixPath('/Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/._e13_16f1_210302.mono_res.cellinfo.mat'),\n",
-       " PosixPath('/Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat'),\n",
-       " PosixPath('/Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/._e13_16f1_210302.SleepState.states.mat'),\n",
-       " PosixPath('/Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.Behavior.mat'),\n",
-       " PosixPath('/Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/._e13_16f1_210302.Behavior.mat'),\n",
-       " PosixPath('/Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.session.mat'),\n",
-       " PosixPath('/Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/._e13_16f1_210302.session.mat'),\n",
-       " PosixPath('/Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/chanMap.mat'),\n",
-       " PosixPath('/Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/._chanMap.mat')]"
+       "[PosixPath('/Volumes/neurodata/buzaki/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.cell_metrics.cellinfo.mat'),\n",
+       " PosixPath('/Volumes/neurodata/buzaki/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/._e13_16f1_210302.cell_metrics.cellinfo.mat'),\n",
+       " PosixPath('/Volumes/neurodata/buzaki/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.ripples.events.mat'),\n",
+       " PosixPath('/Volumes/neurodata/buzaki/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/._e13_16f1_210302.ripples.events.mat'),\n",
+       " PosixPath('/Volumes/neurodata/buzaki/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.spikes.cellinfo.mat'),\n",
+       " PosixPath('/Volumes/neurodata/buzaki/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/._e13_16f1_210302.spikes.cellinfo.mat'),\n",
+       " PosixPath('/Volumes/neurodata/buzaki/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.mono_res.cellinfo.mat'),\n",
+       " PosixPath('/Volumes/neurodata/buzaki/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/._e13_16f1_210302.mono_res.cellinfo.mat'),\n",
+       " PosixPath('/Volumes/neurodata/buzaki/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat'),\n",
+       " PosixPath('/Volumes/neurodata/buzaki/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/._e13_16f1_210302.SleepState.states.mat'),\n",
+       " PosixPath('/Volumes/neurodata/buzaki/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.Behavior.mat'),\n",
+       " PosixPath('/Volumes/neurodata/buzaki/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/._e13_16f1_210302.Behavior.mat'),\n",
+       " PosixPath('/Volumes/neurodata/buzaki/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.session.mat'),\n",
+       " PosixPath('/Volumes/neurodata/buzaki/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/._e13_16f1_210302.session.mat'),\n",
+       " PosixPath('/Volumes/neurodata/buzaki/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/chanMap.mat'),\n",
+       " PosixPath('/Volumes/neurodata/buzaki/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/._chanMap.mat')]"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "project_root = Path(\"/Volumes/neurodata/buzaki/HuszarR/HuszarR\")\n",
+    "project_root = Path(\"/Volumes/neurodata/buzaki/HuszarR\")\n",
     "session_path = Path(project_root, \"optotagCA1/e13/e13_16f1/e13_16f1_210302\")\n",
     "session_files_path_list = list(session_path.iterdir())\n",
     "session_files_path_list"
@@ -139,7 +139,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -173,7 +173,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -559,7 +559,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -567,7 +567,23 @@
      "output_type": "stream",
      "text": [
       "/opt/anaconda3/envs/conversion/lib/python3.11/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
-      "  from .autonotebook import tqdm as notebook_tqdm\n"
+      "  from .autonotebook import tqdm as notebook_tqdm\n",
+      "Exception ignored in: <function tqdm.__del__ at 0x10d84e7a0>\n",
+      "Traceback (most recent call last):\n",
+      "  File \"/opt/anaconda3/envs/conversion/lib/python3.11/site-packages/tqdm/std.py\", line 1145, in __del__\n",
+      "    self.close()\n",
+      "  File \"/opt/anaconda3/envs/conversion/lib/python3.11/site-packages/tqdm/notebook.py\", line 286, in close\n",
+      "    self.disp(bar_style='success', check_delay=False)\n",
+      "    ^^^^^^^^^\n",
+      "AttributeError: 'tqdm_notebook' object has no attribute 'disp'\n",
+      "Exception ignored in: <function tqdm.__del__ at 0x10d84e7a0>\n",
+      "Traceback (most recent call last):\n",
+      "  File \"/opt/anaconda3/envs/conversion/lib/python3.11/site-packages/tqdm/std.py\", line 1145, in __del__\n",
+      "    self.close()\n",
+      "  File \"/opt/anaconda3/envs/conversion/lib/python3.11/site-packages/tqdm/notebook.py\", line 286, in close\n",
+      "    self.disp(bar_style='success', check_delay=False)\n",
+      "    ^^^^^^^^^\n",
+      "AttributeError: 'tqdm_notebook' object has no attribute 'disp'\n"
      ]
     },
     {
@@ -577,7 +593,7 @@
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
       "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[19], line 4\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[39mfrom\u001b[39;00m \u001b[39mspikeinterface\u001b[39;00m\u001b[39m.\u001b[39;00m\u001b[39mextractors\u001b[39;00m \u001b[39mimport\u001b[39;00m CellExplorerSortingExtractor\n\u001b[1;32m      3\u001b[0m file_path \u001b[39m=\u001b[39m session_files_path_list[\u001b[39m0\u001b[39m]\u001b[39m.\u001b[39mparent \u001b[39m/\u001b[39m \u001b[39m\"\u001b[39m\u001b[39me13_16f1_210302.spikes.cellinfo.mat\u001b[39m\u001b[39m\"\u001b[39m\n\u001b[0;32m----> 4\u001b[0m extractor \u001b[39m=\u001b[39m CellExplorerSortingExtractor(file_path)\n",
+      "Cell \u001b[0;32mIn[20], line 4\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[39mfrom\u001b[39;00m \u001b[39mspikeinterface\u001b[39;00m\u001b[39m.\u001b[39;00m\u001b[39mextractors\u001b[39;00m \u001b[39mimport\u001b[39;00m CellExplorerSortingExtractor\n\u001b[1;32m      3\u001b[0m file_path \u001b[39m=\u001b[39m session_files_path_list[\u001b[39m0\u001b[39m]\u001b[39m.\u001b[39mparent \u001b[39m/\u001b[39m \u001b[39m\"\u001b[39m\u001b[39me13_16f1_210302.spikes.cellinfo.mat\u001b[39m\u001b[39m\"\u001b[39m\n\u001b[0;32m----> 4\u001b[0m extractor \u001b[39m=\u001b[39m CellExplorerSortingExtractor(file_path)\n",
       "File \u001b[0;32m/opt/anaconda3/envs/conversion/lib/python3.11/site-packages/spikeinterface/extractors/cellexplorersortingextractor.py:41\u001b[0m, in \u001b[0;36mCellExplorerSortingExtractor.__init__\u001b[0;34m(self, spikes_matfile_path, session_info_matfile_path, sampling_frequency)\u001b[0m\n\u001b[1;32m     38\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39m__init__\u001b[39m(\u001b[39mself\u001b[39m, spikes_matfile_path: PathType,\n\u001b[1;32m     39\u001b[0m              session_info_matfile_path: OptionalPathType\u001b[39m=\u001b[39m\u001b[39mNone\u001b[39;00m,\n\u001b[1;32m     40\u001b[0m              sampling_frequency: Optional[\u001b[39mfloat\u001b[39m] \u001b[39m=\u001b[39m \u001b[39mNone\u001b[39;00m):\n\u001b[0;32m---> 41\u001b[0m     \u001b[39massert\u001b[39;00m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39minstalled, \u001b[39mself\u001b[39m\u001b[39m.\u001b[39minstallation_mesg\n\u001b[1;32m     43\u001b[0m     spikes_matfile_path \u001b[39m=\u001b[39m Path(spikes_matfile_path)\n\u001b[1;32m     44\u001b[0m     \u001b[39massert\u001b[39;00m (\n\u001b[1;32m     45\u001b[0m         spikes_matfile_path\u001b[39m.\u001b[39mis_file()\n\u001b[1;32m     46\u001b[0m     ), \u001b[39mf\u001b[39m\u001b[39m\"\u001b[39m\u001b[39mThe spikes_matfile_path (\u001b[39m\u001b[39m{\u001b[39;00mspikes_matfile_path\u001b[39m}\u001b[39;00m\u001b[39m) must exist!\u001b[39m\u001b[39m\"\u001b[39m\n",
       "\u001b[0;31mAssertionError\u001b[0m: To use the CellExplorerSortingExtractor install scipy and hdf5storage: \n\n pip install scipy  hdf5storage"
      ]
@@ -845,7 +861,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -859,10 +875,15 @@
     "\n",
     "\n",
     "    naming_conventions = {}\n",
-    "    for root, dirs, files in tqdm(os.walk(parent_folder)):\n",
-    "        for file in tqdm(files):\n",
+    "    # for root, dirs, files in tqdm(os.walk(parent_folder)):\n",
+    "    #     for file in tqdm(files):\n",
+    "    for root, dirs, files in os.walk(parent_folder):\n",
+    "        for file in files:\n",
     "            filename, ext = os.path.splitext(file)\n",
-    "            if filename and filename[0] != '.':\n",
+    "            # if filename and filename[0] != '.':\n",
+    "            if filename:\n",
+    "                if (filename[0] == '.'): \n",
+    "                    filename = filename[1:]\n",
     "                split_path = filename.split('.')\n",
     "                naming_convention = '.'.join(split_path[1:]) if len(split_path) > 1 else filename # Remove the '.' character\n",
     "                if naming_convention not in naming_conventions:\n",
@@ -900,7 +921,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -910,7 +931,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -929,7 +950,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -962,9 +983,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 36,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "This dataset has some missing files\n"
+     ]
+    }
+   ],
    "source": [
     "missing = check_missing_files(structure)\n",
     "with open(json_directory / 'project' / 'missing_files.json', 'w') as f:\n",
@@ -981,19 +1010,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [],
    "source": [
     "def get_file_data(file, root, **kwargs):\n",
     "    filename, ext = os.path.splitext(file_path)\n",
     "    if (ext == '.mat'):\n",
-    "        mat_file = loadmat_scipy(Path(root, file), simplify_cells=True)\n",
-    "        return build_keys_and_types(mat_file)\n",
+    "        try:\n",
+    "            mat_file = loadmat_scipy(Path(root, file), simplify_cells=True)\n",
+    "            return build_keys_and_types(mat_file)\n",
+    "        except: \n",
+    "            print(f'{file} is not readable by loadmat_scipy')\n",
     "\n",
     "    else:\n",
     "        print(f'Cannot handle {file} file type')\n",
-    "        return {}\n",
+    "        \n",
+    "    return {}\n",
     "        \n",
     "def aggregate_data(parent_folder):\n",
     "    return aggregate_file_info(parent_folder, get_file_data, {})"
@@ -1009,88 +1042,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 40,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n",
-      "Starting to load /Volumes/neurodata/buzaki/HuszarR/HuszarR/optotagCA1/e13/e13_16f1/e13_16f1_210302/e13_16f1_210302.SleepState.states.mat\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "data = aggregate_data(project_root)\n",
     "project_data_path = json_directory / 'project' / 'data.json'\n",
@@ -1108,7 +1062,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1122,14 +1076,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "dict_keys(['e13_16f1_210328.cell_metrics.cellinfo.mat', 'e13_16f1_210302.cell_metrics.cellinfo.mat', 'e13_16f1_210331.cell_metrics.cellinfo.mat', 'e13_16f1_210312.cell_metrics.cellinfo.mat', 'e13_16f1_210319.cell_metrics.cellinfo.mat', 'e13_16f1_210322.cell_metrics.cellinfo.mat', 'e13_16f1_210317.cell_metrics.cellinfo.mat', 'e13_16f1_210314.cell_metrics.cellinfo.mat', 'e13_16f1_210315.cell_metrics.cellinfo.mat'])\n"
+      "dict_keys(['._optotagCA1'])\n"
+     ]
+    },
+    {
+     "ename": "AttributeError",
+     "evalue": "'str' object has no attribute 'keys'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[43], line 61\u001b[0m\n\u001b[1;32m     59\u001b[0m first_key \u001b[39m=\u001b[39m \u001b[39mnext\u001b[39m(\u001b[39miter\u001b[39m(project_data_json))\n\u001b[1;32m     60\u001b[0m \u001b[39mprint\u001b[39m(project_data_json[first_key]\u001b[39m.\u001b[39mkeys())\n\u001b[0;32m---> 61\u001b[0m inconsistencies \u001b[39m=\u001b[39m { key: check_consistency(project_data_json[first_key], check_missing_props) \u001b[39mfor\u001b[39;49;00m key, data \u001b[39min\u001b[39;49;00m project_data_json\u001b[39m.\u001b[39;49mitems() }\n\u001b[1;32m     63\u001b[0m \u001b[39mwith\u001b[39;00m \u001b[39mopen\u001b[39m(json_directory \u001b[39m/\u001b[39m \u001b[39m'\u001b[39m\u001b[39mproject\u001b[39m\u001b[39m'\u001b[39m \u001b[39m/\u001b[39m \u001b[39m'\u001b[39m\u001b[39mdata_inconsistencies.json\u001b[39m\u001b[39m'\u001b[39m, \u001b[39m'\u001b[39m\u001b[39mw\u001b[39m\u001b[39m'\u001b[39m) \u001b[39mas\u001b[39;00m f:\n\u001b[1;32m     64\u001b[0m     f\u001b[39m.\u001b[39mwrite(json\u001b[39m.\u001b[39mdumps( \n\u001b[1;32m     65\u001b[0m         { key: data \u001b[39mfor\u001b[39;00m key, data \u001b[39min\u001b[39;00m inconsistencies\u001b[39m.\u001b[39mitems() \u001b[39mif\u001b[39;00m \u001b[39mlen\u001b[39m(data) } , indent\u001b[39m=\u001b[39m\u001b[39m4\u001b[39m))\n",
+      "Cell \u001b[0;32mIn[43], line 61\u001b[0m, in \u001b[0;36m<dictcomp>\u001b[0;34m(.0)\u001b[0m\n\u001b[1;32m     59\u001b[0m first_key \u001b[39m=\u001b[39m \u001b[39mnext\u001b[39m(\u001b[39miter\u001b[39m(project_data_json))\n\u001b[1;32m     60\u001b[0m \u001b[39mprint\u001b[39m(project_data_json[first_key]\u001b[39m.\u001b[39mkeys())\n\u001b[0;32m---> 61\u001b[0m inconsistencies \u001b[39m=\u001b[39m { key: check_consistency(project_data_json[first_key], check_missing_props) \u001b[39mfor\u001b[39;00m key, data \u001b[39min\u001b[39;00m project_data_json\u001b[39m.\u001b[39mitems() }\n\u001b[1;32m     63\u001b[0m \u001b[39mwith\u001b[39;00m \u001b[39mopen\u001b[39m(json_directory \u001b[39m/\u001b[39m \u001b[39m'\u001b[39m\u001b[39mproject\u001b[39m\u001b[39m'\u001b[39m \u001b[39m/\u001b[39m \u001b[39m'\u001b[39m\u001b[39mdata_inconsistencies.json\u001b[39m\u001b[39m'\u001b[39m, \u001b[39m'\u001b[39m\u001b[39mw\u001b[39m\u001b[39m'\u001b[39m) \u001b[39mas\u001b[39;00m f:\n\u001b[1;32m     64\u001b[0m     f\u001b[39m.\u001b[39mwrite(json\u001b[39m.\u001b[39mdumps( \n\u001b[1;32m     65\u001b[0m         { key: data \u001b[39mfor\u001b[39;00m key, data \u001b[39min\u001b[39;00m inconsistencies\u001b[39m.\u001b[39mitems() \u001b[39mif\u001b[39;00m \u001b[39mlen\u001b[39m(data) } , indent\u001b[39m=\u001b[39m\u001b[39m4\u001b[39m))\n",
+      "Cell \u001b[0;32mIn[43], line 7\u001b[0m, in \u001b[0;36mcheck_consistency\u001b[0;34m(data, user_check_function, base)\u001b[0m\n\u001b[1;32m      5\u001b[0m \u001b[39m# Loop through objects to discover expected properties\u001b[39;00m\n\u001b[1;32m      6\u001b[0m \u001b[39mfor\u001b[39;00m k, obj \u001b[39min\u001b[39;00m data\u001b[39m.\u001b[39mitems():\n\u001b[0;32m----> 7\u001b[0m     props \u001b[39m=\u001b[39m \u001b[39mset\u001b[39m(obj\u001b[39m.\u001b[39;49mkeys())\n\u001b[1;32m      8\u001b[0m     expected_props \u001b[39m=\u001b[39m expected_props\u001b[39m.\u001b[39munion(props)\n\u001b[1;32m     10\u001b[0m \u001b[39m# Check objects for inconsistencies\u001b[39;00m\n",
+      "\u001b[0;31mAttributeError\u001b[0m: 'str' object has no attribute 'keys'"
      ]
     }
    ],

--- a/buzsaki_lab_to_nwb/huszar_hippocampus_dynamics/files_documentation.ipynb
+++ b/buzsaki_lab_to_nwb/huszar_hippocampus_dynamics/files_documentation.ipynb
@@ -71,6 +71,15 @@
    "source": [
     "project_root = Path(\"/Volumes/neurodata/buzaki/HuszarR\")\n",
     "session_path = Path(project_root, \"optotagCA1/e13/e13_16f1/e13_16f1_210302\")\n",
+    "\n",
+    "# Dump to a file in the same folder\n",
+    "json_directory = Path.cwd() / \"_json_files\"\n",
+    "json_directory.mkdir(exist_ok=True)\n",
+    "\n",
+    "# Dump project-wide information into a nested folder\n",
+    "project_json_directory = json_directory / \"project\"\n",
+    "project_json_directory.mkdir(exist_ok=True)\n",
+    "\n",
     "session_files_path_list = list(session_path.iterdir())\n",
     "session_files_path_list"
    ]
@@ -219,9 +228,6 @@
     "result = build_keys_and_types(mat_file)\n",
     "json_output = json.dumps(result, indent=2)\n",
     "\n",
-    "# Dump to a file in the same folder\n",
-    "json_directory = Path.cwd() / \"_json_files\"\n",
-    "json_directory.mkdir(exist_ok=True)\n",
     "with open(json_directory / 'sleep_state_dict.json', 'w') as f:\n",
     "    f.write(json_output)\n",
     "    "
@@ -921,22 +927,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "project_json_directory = Path.cwd() / \"_json_files\" / \"project\"\n",
-    "project_json_directory.mkdir(exist_ok=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 34,
    "metadata": {},
    "outputs": [],
    "source": [
     "structure = count_file_naming_conventions(project_root)\n",
-    "with open(json_directory / 'project' / 'structure.json', 'w') as f:\n",
+    "with open(project_json_directory / 'structure.json', 'w') as f:\n",
     "    f.write(json.dumps(structure, indent=4))"
    ]
   },
@@ -996,7 +992,7 @@
    ],
    "source": [
     "missing = check_missing_files(structure)\n",
-    "with open(json_directory / 'project' / 'missing_files.json', 'w') as f:\n",
+    "with open(project_json_directory / 'missing_files.json', 'w') as f:\n",
     "    f.write(json.dumps(missing, indent=4))"
    ]
   },
@@ -1047,8 +1043,7 @@
    "outputs": [],
    "source": [
     "data = aggregate_data(project_root)\n",
-    "project_data_path = json_directory / 'project' / 'data.json'\n",
-    "with open(project_data_path, 'w') as f:\n",
+    "with open(project_json_directory / 'data.json', 'w') as f:\n",
     "    f.write(json.dumps(data, indent=4))"
    ]
   },
@@ -1066,9 +1061,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "project_data_path = json_directory / 'project' / 'data.json'\n",
-    "\n",
-    "with open(project_data_path) as user_file:\n",
+    "with open(project_json_directory / 'data.json') as user_file:\n",
     "  file_contents = user_file.read()\n",
     "  \n",
     "project_data_json = json.loads(file_contents)\n"
@@ -1163,7 +1156,7 @@
     "print(project_data_json[first_key].keys())\n",
     "inconsistencies = { key: check_consistency(project_data_json[first_key], check_missing_props) for key, data in project_data_json.items() }\n",
     "\n",
-    "with open(json_directory / 'project' / 'data_inconsistencies.json', 'w') as f:\n",
+    "with open(project_json_directory / 'data_inconsistencies.json', 'w') as f:\n",
     "    f.write(json.dumps( \n",
     "        { key: data for key, data in inconsistencies.items() if len(data) } , indent=4))\n",
     "    "


### PR DESCRIPTION
Added a few improvements to the previous comparison code. 

1. For some reason, I wasn't able to use `tqdm` in the notebook, so those function calls were removed
2. I cleaned up my directory structure and moved some of the folder setup earlier to a single cell
3. Based on @h-mayorquin's question in #57, I am printing a message if a file is unreadable rather than filtering out files prepended with a `.`. 